### PR TITLE
(#23) Remove AOT compilation

### DIFF
--- a/src/TimeStamper.Tool/TimeStamper.Tool.csproj
+++ b/src/TimeStamper.Tool/TimeStamper.Tool.csproj
@@ -24,4 +24,8 @@
     <ItemGroup>
 	    <Compile Include="../TimeStamper/**/*.cs" Exclude="../TimeStamper/obj/**/*.*;../TimeStamper/bin/**/*.*" />
     </ItemGroup>
+
+    <ItemGroup>
+      <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+    </ItemGroup>
 </Project>

--- a/src/TimeStamper/Configuration.cs
+++ b/src/TimeStamper/Configuration.cs
@@ -12,7 +12,7 @@ namespace TimeStamper
         public string InformationalSequence;
         public string TimeStampFormat;
         private readonly string _configFile;
-        private readonly XmlSerializer _serializer = new XmlSerializer(typeof(Configuration));
+        private readonly XmlSerializer _serializer = new(typeof(Configuration));
 
         public Configuration(string configDirectory)
         {
@@ -21,6 +21,8 @@ namespace TimeStamper
             LoadConfiguration();
         }
 
+        // The xml serializer required a parameterless constructor.
+        [JetBrains.Annotations.UsedImplicitly]
         public Configuration() { }
 
         private void LoadConfiguration()
@@ -35,11 +37,16 @@ namespace TimeStamper
             }
 
             TextReader reader = new StreamReader(_configFile);
-            var config = _serializer.Deserialize(reader) as Configuration;
+
+            if (_serializer.Deserialize(reader) is not Configuration config)
+            {
+                return;
+            }
+            
             reader.Close();
             // Override the defaults
             ShouldOutputFooter = config.ShouldOutputFooter;
-            ShouldOutputFooter = config.ShouldOutputHeader;
+            ShouldOutputHeader = config.ShouldOutputHeader;
             StandardOutputSequence = config.StandardOutputSequence;
             StandardErrorSequence = config.StandardErrorSequence;
             InformationalSequence = config.InformationalSequence;
@@ -58,7 +65,7 @@ namespace TimeStamper
         }
         private void SaveConfiguration()
         {
-            TextWriter writer = new StreamWriter(_configFile);
+            using TextWriter writer = new StreamWriter(_configFile);
             _serializer.Serialize(writer, this);
             writer.Close();
         }

--- a/src/TimeStamper/Program.cs
+++ b/src/TimeStamper/Program.cs
@@ -16,17 +16,17 @@ namespace TimeStamper
 
             if (shouldDebug)
             {
-                Console.WriteLine("Waiting up to 2 minutes for debugger to be attached");
-                Console.WriteLine($"Process ID: {Environment.ProcessId}");
+                Console.WriteLine(Strings.AwaitDebugger);
+                Console.WriteLine($"{Strings.ProcessId} {Environment.ProcessId}");
                 var sw = Stopwatch.StartNew();
-                while (!Debugger.IsAttached && sw.ElapsedMilliseconds < 120000)
+                while (!Debugger.IsAttached && sw.ElapsedMilliseconds < 120_000)
                 {
                     Thread.Sleep(100);
                 }
                 
                 if (!Debugger.IsAttached)
                 {
-                    Console.WriteLine("Debugger was not attached in time.");
+                    Console.WriteLine(Strings.NoDebugger);
                 }
                 else
                 {
@@ -39,7 +39,7 @@ namespace TimeStamper
 
             if (args.Length == 0)
             {
-                throw new ArgumentOutOfRangeException(message: "TimeStamper must be called with the executable path to run.", innerException: null);
+                throw new ArgumentOutOfRangeException(message: Strings.InvalidCall, innerException: null);
             }
 
             var arguments = args.Select(
@@ -60,7 +60,7 @@ namespace TimeStamper
 
             if (!File.Exists(processName))
             {
-                throw new FileNotFoundException("We can't launch a program that doesn't exist.", processName);
+                throw new FileNotFoundException(Strings.ProcessNotFound, processName);
             }
 
             var configDirectory = Path.Combine(
@@ -70,23 +70,22 @@ namespace TimeStamper
 
             if (!isRedirected && config.ShouldOutputHeader)
             {
-                //Console.Out.PrintLine("=======================".Colorize(config.InformationalSequence), config.InformationalSequence, config.TimeStampFormat);
                 Console.Out
                     .PrintLine(
-                        "Executable Path: " + $"{processName}".Colorize(config.InformationalSequence),
+                        $"{Strings.ProcessPath} {processName.Colorize(config.InformationalSequence)}",
                         config.InformationalSequence,
                         config.TimeStampFormat);
                 Console.Out
                     .PrintLine(
-                        "Parameters: " + string.Join(',',arguments.Select(a => a.Colorize(config.InformationalSequence))),
+                        $"{Strings.Parameters} {string.Join(',',arguments.Select(a => a.Colorize(config.InformationalSequence)))}",
                         config.InformationalSequence,
                         config.TimeStampFormat);
                 Console.Out
                     .PrintLine(
-                        "Parameters as passed to process: " + argumentsToProcess,
+                        $"{Strings.ParametersPassed} {argumentsToProcess}",
                         config.InformationalSequence,
                         config.TimeStampFormat);
-                Console.Out.PrintLine("=======================".Colorize(config.InformationalSequence), config.InformationalSequence, config.TimeStampFormat);
+                Console.Out.PrintLine(Strings.HorizontalRule.Colorize(config.InformationalSequence), config.InformationalSequence, config.TimeStampFormat);
             }
 
             using var process = new Process
@@ -127,9 +126,9 @@ namespace TimeStamper
             
             if (!isRedirected && config.ShouldOutputFooter)
             {
-                Console.Out.PrintLine("=======================".Colorize(config.InformationalSequence), config.InformationalSequence, config.TimeStampFormat);
-                Console.Out.PrintLine("Exit Code: " + $"{process.ExitCode}".Colorize(config.InformationalSequence), config.InformationalSequence, config.TimeStampFormat);
-                Console.Out.PrintLine("Runtime: " + $"{stopwatch.Elapsed}".Colorize(config.InformationalSequence), config.InformationalSequence, config.TimeStampFormat);
+                Console.Out.PrintLine(Strings.HorizontalRule.Colorize(config.InformationalSequence), config.InformationalSequence, config.TimeStampFormat);
+                Console.Out.PrintLine($"{Strings.ExitCode} {process.ExitCode.ToString().Colorize(config.InformationalSequence)}", config.InformationalSequence, config.TimeStampFormat);
+                Console.Out.PrintLine($"{Strings.Duration} {stopwatch.Elapsed.ToString().Colorize(config.InformationalSequence)}", config.InformationalSequence, config.TimeStampFormat);
             }
 
             return process.ExitCode;

--- a/src/TimeStamper/Strings.cs
+++ b/src/TimeStamper/Strings.cs
@@ -1,0 +1,17 @@
+﻿namespace TimeStamper
+{
+    public static class Strings
+    {
+        public const string HorizontalRule = "=======================";
+        public const string AwaitDebugger = "Waiting up to 2 minutes for debugger to be attached";
+        public const string NoDebugger = "Debugger was not attached in time.";
+        public const string ProcessId = "Process ID:";
+        public const string InvalidCall = "TimeStamper must be called with the executable path to run.";
+        public const string Parameters = "Parameters:";
+        public const string ParametersPassed = "Parameters as passed to process:";
+        public const string ProcessPath = "Executable being called:";
+        public const string ExitCode = "Exit Code:";
+        public const string Duration = "Execution Duration:";
+        public const string ProcessNotFound = "We can't launch a program that doesn't exist.";
+    }
+}

--- a/src/TimeStamper/TimeStamper.csproj
+++ b/src/TimeStamper/TimeStamper.csproj
@@ -5,12 +5,17 @@
     <TargetFrameworks>net8.0</TargetFrameworks>
     <AssemblyName>TimeStamper</AssemblyName>
     <SelfContained>true</SelfContained>
-    <PublishAot>true</PublishAot>
+	<PublishSingleFile>true</PublishSingleFile>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <Title>TimeStamper</Title>
     <Description>Wrap around any CLI tool you might use, and stamp both standard output and standard
       error with the current time down to the second.</Description>
     <IsPackable>false</IsPackable>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
It seems that AOT compilation results in a binary that can't handle the serialization or deserialization of the configuration object. Instead of compiling for AOT, will just compile as single file and ship dotnet in the exe :shrug: